### PR TITLE
fix: make dbt error message go away

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -14,7 +14,7 @@ macro-paths: ["macros"]
 target-path: "target"
 clean-targets:
     - "target"
-    - "dbt_modules"
+    - "dbt_packages"
     - "logs"
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]


### PR DESCRIPTION
fix: make dbt error message go away

dbt clean gave a warning that dbt_modules has been deprecated
